### PR TITLE
Fix incorrect import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,6 @@ export {
   blockRenderMapForSameWrapperAsUnorderedListItem,
   WRAPPER
 } from './blockRenderMap'
-export { default as CheckableListItem, CheckableListItemBlock } from './CheckableListItem'
+export { default as CheckableListItem } from './CheckableListItem'
 export { default as CheckableListItemUtils } from './CheckableListItemUtils'
 export * from './constants'


### PR DESCRIPTION
`CheckableListItemBlock` was being imported from `./CheckableListItem` despite it not actually existing or being exported from there.

This throws warning in webpack every single build and rebuild.